### PR TITLE
Set campaign_id to 0 if creating new campaign

### DIFF
--- a/application/model/admin/class-campaigns-admin.php
+++ b/application/model/admin/class-campaigns-admin.php
@@ -409,8 +409,9 @@ class Campaigns_Admin extends Admin {
     }
 
 	public function get_field_value( $field ) {
-		$campaign_model = new \PeerRaiser\Model\Campaign( $_GET['campaign'] );
-		$short_field = substr( $field['id'], 12 );
+		$campaign_id    = isset( $_GET['campaign'] ) ? $_GET['campaign'] : 0;
+		$campaign_model = new \PeerRaiser\Model\Campaign( $campaign_id );
+		$short_field    = substr( $field['id'], 12 );
 
 		switch ( $field['id'] ) {
 			case '_peerraiser_default_fundraiser_title':


### PR DESCRIPTION
When creating a new campaign, the function `get_field_value` uses the Campaign model to get the current values. The code was looking for an `id` URL parameter, but there isn't one when you create a new campaign, so we need a fallback of 0.